### PR TITLE
Humbly submit that Utility is a more descriptive category than Graphics.

### DIFF
--- a/snap/gui/hushboard.desktop
+++ b/snap/gui/hushboard.desktop
@@ -9,4 +9,4 @@ Icon=${SNAP}/hushboard/icons/hushboard.svg
 Exec=hushboard
 Terminal=false
 Keywords=audio;mute;microphone;conference;call;
-Categories=GTK;Graphics;
+Categories=GTK;Utility;


### PR DESCRIPTION
I feel rather silly that my first ever pull request is for something so trivial, but I couldn't help but notice that the desktop category was listed as "Graphics" rather than "Utility," which to me is more intuitive. The former could lead users on an interesting hunt in a more traditional application menu found on XFCE and MATE (or even Plasma, for that matter).

I hope I'm not being too forward or presumptive. Thanks for making a killer app :)