### PR TITLE
Add an optional push/toggle to talk feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Own notes:
+ python3 -m venv venv --system-site-packages
+apt install gir1.2-appindicator3-0.1
 # Hushboard
 
 ![icon](https://raw.githubusercontent.com/stuartlangridge/hushboard/main/hushboard/icons/hushboard.svg)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ If you're on Arch (btw), there's also an AUR package available for installation:
 ```bash
 yay -S hushboard-git
 ```
+## Configuration
+Create a configuration file in your .config folder
+
+```bash
+touch ~/.config/hushboard.cfg
+```
+The using your favorite editor start by adding a section at the top, then add the needed configurations e.g.
+```
+[Default]
+PushKey = 108
+ToggleKey = 64
+MuteTimeMs = 500
+```
+Setting the PushKey or ToggleKey will also enable push to talk instead of type to mute
+For possible keycodes use e.g. exv
 
 ## Manual installation
 

--- a/hushboard/__main__.py
+++ b/hushboard/__main__.py
@@ -165,6 +165,12 @@ class HushboardIndicator(GObject.GObject):
         self.mpaused.show()
         self.menu.append(self.mpaused)
 
+        if config.push_to_toggle:
+            mtoggle = Gtk.MenuItem.new_with_mnemonic("_Toggle")
+            mtoggle.connect("activate", self.toggle_mute, None)
+            mtoggle.show()
+            self.menu.append(mtoggle)
+
         mabout = Gtk.MenuItem.new_with_mnemonic("_About")
         mabout.connect("activate", self.show_about, None)
         mabout.show()
@@ -191,6 +197,12 @@ class HushboardIndicator(GObject.GObject):
             thread = threading.Thread(target=xlistener, args=(self.key_pressed,))
         thread.daemon = True
         thread.start()
+
+    def toggle_mute(self, *args):
+        if currentOp == "unmute":
+            self.mute()
+        else:
+            self.unmute()
 
     def toggle_paused(self, widget, *args):
         if widget.get_active():
@@ -219,10 +231,7 @@ class HushboardIndicator(GObject.GObject):
                 self.mute()
         elif config.push_to_toggle and keydetail == config.push_to_toggle_key:
             if keyevent == X.KeyPress:
-                if currentOp == "unmute":
-                    self.mute()
-                else:
-                    self.unmute()
+                self.toggle_mute()
        
 
     def quit(self, *args):

--- a/hushboard/__main__.py
+++ b/hushboard/__main__.py
@@ -212,12 +212,12 @@ class HushboardIndicator(GObject.GObject):
         if self.mpaused.get_active(): return
         keyevent = args[0]
         keydetail = args[1]
-        if keydetail == config.push_to_talk_key:
+        if config.push_to_talk and keydetail == config.push_to_talk_key:
             if keyevent == X.KeyPress:
                 self.unmute()
             elif keyevent == X.KeyRelease:
                 self.mute()
-        elif keydetail == config.push_to_toggle_key:
+        elif config.push_to_toggle and keydetail == config.push_to_toggle_key:
             if keyevent == X.KeyPress:
                 if currentOp == "unmute":
                     self.mute()

--- a/hushboard/config.py
+++ b/hushboard/config.py
@@ -9,8 +9,12 @@ mute_time_ms = 250
 
 def load_configuration(self):
     config = configparser.ConfigParser()
-    config.read(os.path.expanduser('~/.config/hushboard.cfg'))
-
+    try:
+        config.read(os.path.expanduser('~/.config/hushboard.cfg'))
+    except (configparser.NoSectionError, configparser.MissingSectionHeaderError):
+        print("No section header found in file")
+        return
+    
     default_section = 'Default'
 
     if not config.has_section(default_section):

--- a/hushboard/config.py
+++ b/hushboard/config.py
@@ -1,0 +1,35 @@
+import os
+import configparser
+
+push_to_talk = False
+push_to_talk_key = None
+push_to_toggle = False
+push_to_toggle_key = None
+mute_time_ms = 250
+
+def load_configuration(self):
+    config = configparser.ConfigParser()
+    config.read(os.path.expanduser('~/.config/hushboard.cfg'))
+
+    default_section = 'Default'
+
+    if not config.has_section(default_section):
+        return
+
+    hushConfig = config[default_section]
+
+    if config.has_option(default_section,'PushKey'):
+        global push_to_talk
+        push_to_talk = True
+        global push_to_talk_key
+        push_to_talk_key = hushConfig.getint('PushKey')
+
+    if config.has_option(default_section,'ToggleKey'):
+        global push_to_toggle
+        push_to_toggle = True
+        global push_to_toggle_key
+        push_to_toggle_key = hushConfig.getint('ToggleKey')
+    
+    if config.has_option(default_section,'MuteTimeMs'):
+        global mute_time_ms
+        mute_time_ms = hushConfig.getint('MuteTimeMs')


### PR DESCRIPTION
Hi, I have made the following features for your consideration.
They are all optional relative to the current implementation, and will only be active if configured to be so.

- Add feature to allow push to talk (Initial PoC implementation by  @tobalr)
- Add feature to allow toggle to mute/unmute
- Add a button to app indicator, that toggles mute/unmute
- Add support for a config file so the user can set
  - To enable and set which key to use for push to talk
  - To enable and set which key to use for toggle
  - The wait duration during type to mute (Also works with type to mute)

NB: python is not my main language, so they may be style issues with my implementation.
Feel free to leave a comment if something should be refactored.